### PR TITLE
fixed baud rate for Neo-M9N-00B

### DIFF
--- a/examples/getPosition/getPosition.ino
+++ b/examples/getPosition/getPosition.ino
@@ -24,7 +24,7 @@ static void printStr(const char *str, int len);
 
 void setup() {
     Serial.begin(115200);
-    Serial2.begin(115200, SERIAL_8N1, 16, 17);
+    Serial2.begin(38400, SERIAL_8N1, 16, 17); // changed for NEO-M9N-00B default baud rate.
 
     Serial.println();
     Serial.println(F(


### PR DESCRIPTION
Hi, I have build and uploaded getPosition.ino example to my M5Grey(MPU6886+BMM150). However, it will not work Rx data correctly. Only shows bunch of "******" forever. I have looked Neo-M9N datasheet page 15. 
![image](https://github.com/m5stack/M5Module-GNSS/assets/77033891/e8aa8c05-2f57-47d9-a1d4-a7d696efc633)
 I have changed Serial2 boud rate 38400, then it works well. Please review the code.

Environments:
VSCODE+Platform IO 
~~~[env:m5stack-grey]
platform = espressif32
board = m5stack-grey
framework = arduino
lib_deps =
        mikalhart/tinyGPSplus
~~~

OR

Arduino ESP32 2.0.14 M5Stack-Fire(No PSRAM)
mikalhart tinyGPSplus 1.0.3

If you have any, please let me know.